### PR TITLE
Creating polymorhpic union of all action args structs

### DIFF
--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_common.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_common.h
@@ -1,0 +1,15 @@
+#ifndef PNBC_OSC_ACTION_COMMON_H
+#define PNBC_OSC_ACTION_COMMON_H
+
+#include "pnbc_osc_action_decrement.h"
+#include "pnbc_osc_action_get.h"
+#include "pnbc_osc_action_put.h"
+
+union any_args_t {
+  dec_args_t dec_args;
+  get_args_t get_args;
+  put_args_t put_args;
+};
+typedef union any_args_t any_args_t;
+
+#endif

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
@@ -22,9 +22,7 @@
  */
 #include "pnbc_osc_debug.h"
 #include "pnbc_osc_internal.h"
-#include "pnbc_osc_action_decrement.h"
-#include "pnbc_osc_action_get.h"
-#include "pnbc_osc_action_put.h"
+#include "pnbc_osc_action_common.h"
 
 static inline int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
                               MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *rdispls,
@@ -344,10 +342,10 @@ static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedul
   MPI_Request **requests_moveData = &(schedule->requests[1 * csize * sizeof(MPI_Request*)]); // combine into PUT_NOTIFY?
   MPI_Request **requests_rputDONE = &(schedule->requests[2 * csize * sizeof(MPI_Request*)]); // combine into PUT_NOTIFY?
 
-  schedule->action_args_list = malloc(3 * csize * sizeof(put_args_t));
-  put_args_t *action_args_FLAG = &(schedule->action_args_list[0 * csize * sizeof(put_args_t)]); // TODO:should be polymorphic args
-  put_args_t *action_args_DATA = &(schedule->action_args_list[1 * csize * sizeof(put_args_t)]); // TODO:should be polymorphic args
-  put_args_t *action_args_DONE = &(schedule->action_args_list[2 * csize * sizeof(put_args_t)]); // TODO:should be polymorphic args
+  schedule->action_args_list = malloc(3 * csize * sizeof(any_args_t));
+  any_args_t *action_args_FLAG = &(schedule->action_args_list[0 * csize * sizeof(any_args_t)]);
+  any_args_t *action_args_DATA = &(schedule->action_args_list[1 * csize * sizeof(any_args_t)]);
+  any_args_t *action_args_DONE = &(schedule->action_args_list[2 * csize * sizeof(any_args_t)]);
 
   schedule->trigger_arrays = malloc(6 * sizeof(triggerable_array)); // TODO:replace csize*triggerable_single with triggerable_array
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_schedule.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_schedule.h
@@ -32,7 +32,7 @@
 #include "pnbc_osc_trigger_common.h"
 #include "pnbc_osc_trigger_single.h"
 #include "pnbc_osc_trigger_array.h"
-#include "pnbc_osc_action_put.h"
+#include "pnbc_osc_action_common.h"
 
 BEGIN_C_DECLS
 
@@ -148,7 +148,7 @@ struct PNBC_OSC_Schedule {
   triggerable_array *trigger_arrays;    // for trigger-based schedule
   FLAG_t *flags;                        // for trigger-based schedule
   MPI_Request **requests;               // for trigger-based schedule
-  put_args_t *action_args_list;            // for trigger-based schedule
+  any_args_t *action_args_list;         // for trigger-based schedule
   int number_of_rounds;                 // length of array: rounds
   int restart_round;                    // index into array: rounds
   PNBC_OSC_Round *rounds[];             // list of rounds (polymorphic)


### PR DESCRIPTION
Create `any_args_t` as a union of all three existing action argument structures and modified alltoallv_init to use this as a polymorphic type when allocating memory for action arguments.