### PR TITLE
Write the get action code that calls rget using params in get_args

### DIFF
--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_get.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_get.c
@@ -1,16 +1,47 @@
+#include "pnbc_osc_debug.h"
 #include "pnbc_osc_action_get.h"
-
-static enum TRIGGER_ACTION_STATE action_one_get(int index, get_args_t *get_args) {
-  int ret = ACTION_SUCCESS;
-  return ret;
-}
-
-trigger_action_one_cb_fn_t action_one_get_p = (trigger_action_one_cb_fn_t)action_one_get;
 
 static enum TRIGGER_ACTION_STATE action_all_get(get_args_t *get_args) {
   int ret = ACTION_SUCCESS;
+
+PNBC_OSC_DEBUG(5,"*buf: %p, origin count: %i, origin type: %p, target: %i, target count: %i, target type: %p, target displ: %lu)\n",
+                     get_args->buf, get_args->origin_count, get_args->origin_datatype, get_args->target,
+                     get_args->target_count, get_args->target_datatype, get_args->target_displ);
+
+#ifdef PNBC_OSC_TIMING
+      Iget_time -= MPI_Wtime();
+#endif
+
+      ret = get_args->win->w_osc_module->osc_rget(get_args->buf,
+                                                get_args->origin_count, get_args->origin_datatype,
+                                                get_args->target, get_args->target_displ,
+                                                get_args->target_count, get_args->target_datatype,
+                                                get_args->win, get_args->request);
+      //handle->req_count++;
+
+      if (OMPI_SUCCESS != ret) {
+        PNBC_OSC_Error("Error in osc_rget(%p, %i, %p, %i, %lu, %i, %p) (%i)",
+                       get_args->buf,
+                       get_args->origin_count, get_args->origin_datatype,
+                       get_args->target, get_args->target_displ,
+                       get_args->target_count, get_args->target_datatype,
+                       ret);
+      }
+
+#ifdef PNBC_OSC_TIMING
+      Iget_time += MPI_Wtime();
+#endif
+
+
+
   return ret;
 }
 
 trigger_action_all_cb_fn_t action_all_get_p = (trigger_action_all_cb_fn_t)action_all_get;
+
+static enum TRIGGER_ACTION_STATE action_one_get(int index, get_args_t *get_args) {
+  return action_all_get(get_args);
+}
+
+trigger_action_one_cb_fn_t action_one_get_p = (trigger_action_one_cb_fn_t)action_one_get;
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_get.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_get.h
@@ -2,9 +2,19 @@
 #define PNBC_OSC_ACTION_GET_H
 
 #include "pnbc_osc_trigger_common.h"
+#include "ompi/request/request.h"
+#include "ompi/win/win.h"
 
 struct get_args_t {
-  int temp;
+  MPI_Win win;
+  void *buf;
+  int origin_count;
+  MPI_Datatype origin_datatype;
+  int target;
+  MPI_Aint target_displ;
+  int target_count;
+  MPI_Datatype target_datatype;
+  MPI_Request *request;
 };
 typedef struct get_args_t get_args_t;
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_debug.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_debug.h
@@ -1,3 +1,6 @@
+#ifndef PNBC_OSC_DEBUG_H
+#define PNBC_OSC_DEBUG_H
+
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -23,10 +26,19 @@ static inline void PNBC_OSC_DEBUG(int level, const char *fmt, ...) {
 #endif
 }
 
+static inline void PNBC_OSC_Error (char *format, ...) {
+  va_list args;
+
+  va_start (args, format);
+  vfprintf (stderr, format, args);
+  fprintf (stderr, "\n");
+  va_end (args);
+}
+
 #ifdef PNBC_OSC_TIMING
 extern double Iput_time,Iget_time,Isend_time, Irecv_time, Wait_time, Test_time,Iwfree_time;
 static inline void PNBC_OSC_Reset_times(void);
 static inline void PNBC_OSC_Print_times(double div);
 #endif
 
-
+#endif

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_internal.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_internal.h
@@ -38,6 +38,7 @@
 #include "ompi/communicator/communicator.h"
 #include "ompi/win/win.h"
 
+#include "pnbc_osc_debug.h"
 #include "coll_libpnbc_osc.h"
 #include "pnbc_osc_request.h"
 
@@ -221,14 +222,6 @@ int PNBC_OSC_Create_fortran_handle(int *fhandle, PNBC_OSC_Handle **handle);
   
   /* some macros */
   
-  static inline void PNBC_OSC_Error (char *format, ...) {
-    va_list args;
-
-    va_start (args, format);
-    vfprintf (stderr, format, args);
-    fprintf (stderr, "\n");
-    va_end (args);
-  }
 
   /* a schedule has the following format:
    * [schedule] ::= [size][round-schedule][delimiter][round-schedule][delimiter]...[end]


### PR DESCRIPTION
Copy the call to rget from a previous version of pnbc_osc.c (I used https://github.com/EPiGRAM-HS/ompi/pull/23/files).
Fixup the usage of "handle" to refer to fields in the get_args_t struct passed in to the action.
Add all the missing fields into the get_args_t struct definition.
Side-effect: move the PNBC_OSC_Error function from pnbc_osc_internal.h into pnbc_osc_debug.h