### PR TITLE
Libpnbc osc feature create action put

### DIFF
--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.c
@@ -1,16 +1,47 @@
+#include "pnbc_osc_debug.h"
 #include "pnbc_osc_action_put.h"
 
-static enum TRIGGER_ACTION_STATE action_one_put(int index, put_args_t *put_args) {
+static enum TRIGGER_ACTION_STATE action_all_put(put_args_t *put_args){
   int ret = ACTION_SUCCESS;
-  return ret;
-}
 
-trigger_action_one_cb_fn_t action_one_put_p = (trigger_action_one_cb_fn_t)action_one_put;
+PNBC_OSC_DEBUG(5,"*buf: %p, origin count: %i, origin type: %p, target: %i, target count: %i, target type: %p, target displ: %lu)\n",
+                     put_args->buf, put_args->origin_count, put_args->origin_datatype, put_args->target,
+                     put_args->target_count, put_args->target_datatype, put_args->target_displ);
 
-static enum TRIGGER_ACTION_STATE action_all_put(put_args_t *put_args) {
-  int ret = ACTION_SUCCESS;
+#ifdef PNBC_OSC_TIMING
+      Iput_time -= MPI_Wtime();
+#endif
+
+  ret = put_args->win->w_osc_module->osc_rput(put_args->buf,
+                                              put_args->origin_count, put_args->origin_datatype,
+                                              put_args->target, put_args->target_displ,
+                                              put_args->target_count, put_args->target_datatype,
+                                              put_args->win, put_args->request);
+
+
+  if (OMPI_SUCCESS != ret) {
+    PNBC_OSC_Error("Error in osc_rput(%p, %i, %p, %i, %lu, %i, %p) (%i)",
+                   put_args->buf, put_args->origin_count, 
+		   put_args->origin_datatype, put_args->target, 
+		   put_args->target_displ, put_args->target_count, 
+		   put_args->target_datatype, ret);
+  }
+
+
+#ifdef PNBC_OSC_TIMING
+      Iput_time += MPI_Wtime();
+#endif
+
+
+
   return ret;
 }
 
 trigger_action_all_cb_fn_t action_all_put_p = (trigger_action_all_cb_fn_t)action_all_put;
+
+static enum TRIGGER_ACTION_STATE action_one_put(put_args_t *put args) {
+  return action_all_put(put_args);
+}
+
+trigger_action_one_cb_fn_t action_one_put_p = (trigger_action_one_cb_fn_t)action_one_put;
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.c
@@ -39,7 +39,7 @@ PNBC_OSC_DEBUG(5,"*buf: %p, origin count: %i, origin type: %p, target: %i, targe
 
 trigger_action_all_cb_fn_t action_all_put_p = (trigger_action_all_cb_fn_t)action_all_put;
 
-static enum TRIGGER_ACTION_STATE action_one_put(put_args_t *put args) {
+static enum TRIGGER_ACTION_STATE action_one_put(put_args_t *put_args) {
   return action_all_put(put_args);
 }
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.h
@@ -18,6 +18,7 @@ struct put_args_t {
 };
 typedef struct put_args_t put_args_t;
 
+
 //static enum TRIGGER_ACTION_STATE action_all_put(put_args_t *put_args);
 extern trigger_action_all_cb_fn_t action_all_put_p;
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_action_put.h
@@ -2,9 +2,19 @@
 #define PNBC_OSC_ACTION_PUT_H
 
 #include "pnbc_osc_trigger_common.h"
+#include "ompi/request/request.h"
+#include "ompi/win/win.h"
 
 struct put_args_t {
-  int temp;
+  const void *buf;
+  int origin_count;
+  MPI_Datatype origin_datatype;
+  int target;
+  MPI_Aint target_displ;
+  int target_count;
+  MPI_Datatype target_datatype;
+  MPI_Win win;
+  MPI_Request *request;
 };
 typedef struct put_args_t put_args_t;
 


### PR DESCRIPTION
Copy the call to rput from a previous version of pnbc_osc.c 
Add all the missing fields into the put_args_t struct definition