### PR TITLE
Attach flags to window (and general tidy up)

### DIFF
--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
@@ -364,35 +364,35 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
   }
 
   if (0 == schedule->flags_length) {
-    winflag = MPI_WIN_NULL;
+    win = MPI_WIN_NULL;
   } else {
     // create a dynamic window - flags will be signalled here
-    res = ompi_win_create_dynamic(&info->super, comm, &winflag);
-    if (OMPI_SUCCESS != res) {
-      PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
-      free(abs_rdispls_other);
-      free(abs_rdispls_local);
-      MPI_Win_free(&win);
-      OBJ_RELEASE(schedule);
-      return res;
-    }
+//    res = ompi_win_create_dynamic(&info->super, comm, &winflag);
+//    if (OMPI_SUCCESS != res) {
+//      PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
+//      free(abs_rdispls_other);
+//      free(abs_rdispls_local);
+//      MPI_Win_free(&win);
+//      OBJ_RELEASE(schedule);
+//      return res;
+//    }
 
     // attach the flags memory to the winflag window (fsize provided by the schedule)
-    res = win->w_osc_module->osc_win_attach(winflag, schedule->flags, schedule->flags_length);
+    res = win->w_osc_module->osc_win_attach(win, schedule->flags, schedule->flags_length);
     if (OMPI_SUCCESS != res) {
       PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
       free(abs_rdispls_other);
       free(abs_rdispls_local);
       MPI_Win_free(&win);
       OBJ_RELEASE(schedule);
-      MPI_Win_free(&winflag);
+//      MPI_Win_free(&winflag);
       return res;
     }
 
     // lock the flags window at all other processes
-    res = MPI_Win_lock_all(MPI_MODE_NOCHECK, winflag);
+    res = MPI_Win_lock_all(MPI_MODE_NOCHECK, win);
     if (OMPI_SUCCESS != res) {
-      PNBC_OSC_Error ("MPI Error in MPI_Win_lock_all for winflag (%i)", res);
+      PNBC_OSC_Error ("MPI Error in MPI_Win_lock_all for win (%i)", res);
       free(abs_rdispls_other);
       free(abs_rdispls_local);
       MPI_Win_free(&win);

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
@@ -46,8 +46,6 @@ int ompi_coll_libpnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcou
 }
 
 typedef enum {
-  algo_linear_rput,
-  algo_linear_rget,
   algo_trigger_pull,
   algo_trigger_push,
 } a2av_sched_algo;
@@ -55,8 +53,6 @@ typedef enum {
 // pull implies move means get and FLAG means RTS (ready to send)
 static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedule *schedule,
                                           MPI_Win win, MPI_Comm comm,
-//                                          FLAG_t **flags,
-                                          //int *fsize,
                                           const void *sendbuf, const int *sendcounts, const int *sdispls,
                                           MPI_Aint sendext, MPI_Datatype sendtype,
                                                 void *recvbuf, const int *recvcounts, const int *rdispls,
@@ -65,28 +61,12 @@ static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedul
 
 // push implies move means put and FLAG means CTS (clear to send)
 static inline int a2av_sched_trigger_push(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                          void *flags, int *fsize, int *req_count,
+                                          MPI_Win win, MPI_Comm comm,
                                           const void *sendbuf, const int *sendcounts, const int *sdispls,
                                           MPI_Aint sendext, MPI_Datatype sendtype,
                                                 void *recvbuf, const int *recvcounts, const int *rdispls,
                                           MPI_Aint recvext, MPI_Datatype recvtype,
                                           MPI_Aint *abs_rdispls_other);
-
-static inline int a2av_sched_linear_rget(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                         void *flags, int *fsize, int *req_count,
-                                         const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                         MPI_Aint sendext, MPI_Datatype sendtype,
-                                               void *recvbuf, const int *recvcounts, const int *rdispls,
-                                         MPI_Aint recvext, MPI_Datatype recvtype,
-                                         MPI_Aint *abs_sdispls_other);
-
-static inline int a2av_sched_linear_rput(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                         void *flags, int *fsize, int *req_count,
-                                         const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                         MPI_Aint sendext, MPI_Datatype sendtype,
-                                               void *recvbuf, const int *recvcounts, const int *rdispls,
-                                         MPI_Aint recvext, MPI_Datatype recvtype,
-                                         MPI_Aint *abs_rdispls_other);
 
 static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, const int *sdispls,
                   MPI_Datatype sendtype, void* recvbuf, const int *recvcounts, const int *rdispls,
@@ -98,15 +78,11 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
   MPI_Aint sendext, recvext;
   PNBC_OSC_Schedule *schedule;
   int crank, csize;
-  MPI_Aint base_sendbuf, abs_sendbuf;
+  MPI_Aint base_sendbuf;
   MPI_Aint *abs_sdispls_other, *abs_sdispls_local;
-  MPI_Aint base_recvbuf, abs_recvbuf;
+  MPI_Aint base_recvbuf;
   MPI_Aint *abs_rdispls_other, *abs_rdispls_local;
-  MPI_Win win, winflag;
-  void *flags = NULL;
-  schedule->flags_length=0;
-  int fsize = 0;
-  int req_count;
+  MPI_Win win;
   ompi_coll_libpnbc_osc_module_t *libpnbc_osc_module = (ompi_coll_libpnbc_osc_module_t*) module;
   int buf_size = 0;
 
@@ -136,16 +112,12 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
   crank = ompi_comm_rank(comm);
   csize = ompi_comm_size(comm);
 
-  // TODO [DanH] add code to examine info and decide which algo to use
-
   a2av_sched_algo algo = algo_trigger_push;
 
   if ( check_config_value_equal("a2av_algo_requested", info, "linear_trigger_pull") )
     algo = algo_trigger_pull;
   if ( check_config_value_equal("a2av_algo_requested", info, "linear_trigger_push") )
     algo = algo_trigger_push;
-
-  // END OF DanH changes for info
 
   // create a dynamic window - data here will be accessed by remote processes
   res = ompi_win_create_dynamic(&info->super, comm, &win);
@@ -154,12 +126,8 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
     return res;
   }
 
-
   switch (algo) {
-    case algo_linear_rput: // ignore
-      break;
-    case algo_linear_rget: // ignore
-      break;
+
     case algo_trigger_pull:
       // uses get to move data from the remote sendbuf - needs sdispls to be exchanged
 
@@ -174,7 +142,6 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
         MPI_Win_free(&win);
         return res;
       }
-      abs_sendbuf = MPI_Aint_add(MPI_BOTTOM, base_sendbuf);
 
       // create an array of displacements where all ranks will gather their window memory base address
       abs_sdispls_other = (MPI_Aint*)malloc(csize * sizeof(MPI_Aint));
@@ -189,36 +156,29 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
         return OMPI_ERR_OUT_OF_RESOURCE;
       }
 
-      // attach all pieces of local sendbuf to local window and record their absolute displacements
+      // compute the total size of all pieces of local sendbuf and record their absolute displacements
       for (int r=0;r<csize;++r) {
         buf_size += sendcounts[r];
-	abs_sdispls_local[r] = MPI_Aint_add(abs_sendbuf, (MPI_Aint)sdispls[r]);
-	PNBC_OSC_DEBUG(1, "[nbc_allreduce_init] %d gets address at disp %ld\n",
+        abs_sdispls_local[r] = MPI_Aint_add(base_sendbuf, (MPI_Aint)sdispls[r]);
+       	PNBC_OSC_DEBUG(20, "[pnbc_alltoallv_init] %d gets address at disp %ld",
                        crank, abs_sdispls_local[r]);
       }
-      
-      res = win->w_osc_module->osc_win_attach(win, (char*)sendbuf, sendext*buf_size);
 
-        //res = win->w_osc_module->osc_win_attach(win, (char*)sendbuf+sdispls[r], sendext*sendcounts[r]);
+      // attach all of the local sendbuf to local window as one large chunk of memory
+      res = win->w_osc_module->osc_win_attach(win, (char*)sendbuf, sendext*buf_size);
       if (OMPI_SUCCESS != res) {
-        PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
+        PNBC_OSC_Error ("MPI Error in win_attach (%i)", res);
         free(abs_sdispls_other);
         free(abs_sdispls_local);
         MPI_Win_free(&win);
         return res;
       }
-//      PNBC_OSC_DEBUG(1, "[pnbc_alltoallv_init] %d attaches to dynamic window memory for rank %d with address %p (computed from sdispl value %d) of size %d bytes (computed from sendcount value %d)\n",
-//                     crank, r,
-//                     (char*)sendbuf+sdispls[r],
-//                     sdispls[r],
-//                     sendext*sendcounts[r],
-//                     sendcounts[r]);
-//
-        // compute displacement of local window memory portion
-      //abs_sdispls_local[r] = MPI_Aint_add(abs_sendbuf, (MPI_Aint)sdispls[r]);
-      //PNBC_OSC_DEBUG(1, "[nbc_allreduce_init] %d gets address at disp %ld\n",
-      //                 crank, abs_sdispls_local[r]);
-      
+      PNBC_OSC_DEBUG(10, "[pnbc_alltoallv_init] %d attaches to dynamic window memory for all ranks with address %p (computed from sdispl value %d) of size %d bytes (computed from sum of sendcount values %d)",
+                     crank,
+                     (char*)sendbuf,
+                     sdispls[0],
+                     sendext*buf_size,
+                     buf_size);
 
       // swap local sdispls for remote sdispls
       // put the displacements for all local portions on the window
@@ -241,6 +201,19 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
       // GET_BASED WINDOW SETUP - END
       // ****************************
 
+      res = a2av_sched_trigger_pull(crank, csize, schedule, win, comm,
+                                    sendbuf, sendcounts, sdispls, sendext, sendtype,
+                                    recvbuf, recvcounts, rdispls, recvext, recvtype,
+                                    abs_sdispls_other);
+      if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
+        PNBC_OSC_Error ("MPI Error in a2av_sched_linear (%i)", res);
+        free(abs_sdispls_other);
+        free(abs_sdispls_local);
+        MPI_Win_free(&win);
+        OBJ_RELEASE(schedule);
+        return res;
+      }
+
       break;
 
     case algo_trigger_push:
@@ -257,7 +230,6 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
         MPI_Win_free(&win);
         return res;
       }
-      abs_recvbuf = MPI_Aint_add(MPI_BOTTOM, base_recvbuf);
     
       // create an array of displacements where all ranks will gather their window memory base address
       abs_rdispls_other = (MPI_Aint*)malloc(csize * sizeof(MPI_Aint));
@@ -290,7 +262,7 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
                        recvcounts[r]);
     
         // compute displacement of local window memory portion
-        abs_rdispls_local[r] = MPI_Aint_add(abs_recvbuf, (MPI_Aint)rdispls[r]);
+        abs_rdispls_local[r] = MPI_Aint_add(base_recvbuf, (MPI_Aint)rdispls[r]);
         PNBC_OSC_DEBUG(1, "[nbc_allreduce_init] %d gets address at disp %ld\n",
                        crank, abs_rdispls_local[r]);
       }
@@ -316,49 +288,45 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
       // PUT_BASED WINDOW SETUP - END
       // ****************************
 
+      res = a2av_sched_trigger_push(crank, csize, schedule, win, comm,
+                                    sendbuf, sendcounts, sdispls, sendext, sendtype,
+                                    recvbuf, recvcounts, rdispls, recvext, recvtype,
+                                    abs_rdispls_other);
+      if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
+        PNBC_OSC_Error ("MPI Error in a2av_sched_linear (%i)", res);
+        free(abs_rdispls_other);
+        free(abs_rdispls_local);
+        MPI_Win_free(&win);
+        OBJ_RELEASE(schedule);
+        return res;
+      }
+
       break;
 
   } // end switch (algo)
 
+  // attach the flags memory to the win window (details provided by the schedule)
+  if (OPAL_UNLIKELY(0 == schedule->flags_length)) {
+    return OMPI_ERROR;
+  } else {
+    res = win->w_osc_module->osc_win_attach(win, schedule->flags, schedule->flags_length);
+    if (OMPI_SUCCESS != res) {
+      PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
+      free(abs_rdispls_other);
+      free(abs_rdispls_local);
+      MPI_Win_free(&win);
+      OBJ_RELEASE(schedule);
+      return res;
+    }
+  }
+
+  // lock the flags window at all other processes
   res = MPI_Win_lock_all(MPI_MODE_NOCHECK, win);
   if (OMPI_SUCCESS != res) {
     PNBC_OSC_Error ("MPI Error in MPI_Win_lock_all (%i)", res);
     free(abs_rdispls_other);
     free(abs_rdispls_local);
     MPI_Win_free(&win);
-    return res;
-  }
-
-  switch (algo) {
-    case algo_linear_rput:
-  res = a2av_sched_linear_rput(crank, csize, schedule, flags, &fsize, &req_count,
-                               sendbuf, sendcounts, sdispls, sendext, sendtype,
-                               recvbuf, recvcounts, rdispls, recvext, recvtype,
-                               abs_rdispls_other);
-    case algo_linear_rget:
-  res = a2av_sched_linear_rget(crank, csize, schedule, flags, &fsize, &req_count,
-                               sendbuf, sendcounts, sdispls, sendext, sendtype,
-                               recvbuf, recvcounts, rdispls, recvext, recvtype,
-                               abs_rdispls_other);
-                             //abs_sdispls_other);
-    case algo_trigger_pull:
-  res = a2av_sched_trigger_pull(crank, csize, schedule, win, comm, //&fsize, //flags, &fsize, &req_count,
-                               sendbuf, sendcounts, sdispls, sendext, sendtype,
-                               recvbuf, recvcounts, rdispls, recvext, recvtype,
-                               abs_rdispls_other);
-    case algo_trigger_push:
-  res = a2av_sched_trigger_push(crank, csize, schedule, flags, &fsize, &req_count,
-                               sendbuf, sendcounts, sdispls, sendext, sendtype,
-                               recvbuf, recvcounts, rdispls, recvext, recvtype,
-                               abs_rdispls_other);
-                             //abs_sdispls_other);
-  }
-  if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
-    PNBC_OSC_Error ("MPI Error in a2av_sched_linear (%i)", res);
-    free(abs_rdispls_other);
-    free(abs_rdispls_local);
-    MPI_Win_free(&win);
-    OBJ_RELEASE(schedule);
     return res;
   }
 
@@ -372,52 +340,13 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
     return res;
   }
 
-  if (0 == schedule->flags_length) {
-    win = MPI_WIN_NULL;
-  } else {
-    // create a dynamic window - flags will be signalled here
-//    res = ompi_win_create_dynamic(&info->super, comm, &winflag);
-//    if (OMPI_SUCCESS != res) {
-//      PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
-//      free(abs_rdispls_other);
-//      free(abs_rdispls_local);
-//      MPI_Win_free(&win);
-//      OBJ_RELEASE(schedule);
-//      return res;
-//    }
-
-    // attach the flags memory to the winflag window (fsize provided by the schedule)
-    res = win->w_osc_module->osc_win_attach(win, schedule->flags, schedule->flags_length);
-    if (OMPI_SUCCESS != res) {
-      PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
-      free(abs_rdispls_other);
-      free(abs_rdispls_local);
-      MPI_Win_free(&win);
-      OBJ_RELEASE(schedule);
-//      MPI_Win_free(&winflag);
-      return res;
-    }
-
-    // lock the flags window at all other processes
-    res = MPI_Win_lock_all(MPI_MODE_NOCHECK, win);
-    if (OMPI_SUCCESS != res) {
-      PNBC_OSC_Error ("MPI Error in MPI_Win_lock_all for win (%i)", res);
-      free(abs_rdispls_other);
-      free(abs_rdispls_local);
-      MPI_Win_free(&win);
-      return res;
-    }
-
-  }
-
-  res = PNBC_OSC_Schedule_request_win(schedule, comm, win, winflag, req_count, libpnbc_osc_module, persistent, request, flags);
+  res = PNBC_OSC_Schedule_request_win(schedule, comm, win, libpnbc_osc_module, persistent, request);
   if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
     PNBC_OSC_Error ("MPI Error in PNBC_OSC_Schedule_request_win (%i)", res);
     free(abs_rdispls_other);
     free(abs_rdispls_local);
     MPI_Win_free(&win);
     OBJ_RELEASE(schedule);
-    MPI_Win_free(&winflag);
     return res;
   }
 
@@ -427,7 +356,7 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
 static const int FLAG_TRUE = !0;
 
 static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                          MPI_Win win, MPI_Comm comm, //int *fsize,
+                                          MPI_Win win, MPI_Comm comm,
                                           const void *sendbuf, const int *sendcounts, const int *sdispls,
                                           MPI_Aint sendext, MPI_Datatype sendtype,
                                                 void *recvbuf, const int *recvcounts, const int *rdispls,
@@ -466,7 +395,7 @@ static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedul
     MPI_Get_address(&flags_rma_put_DONE[i], &DONE_displs_local[i]);
   }
   MPI_Alltoall(flag_displs_local, 2*csize, MPI_AINT, flag_displs_other, 2*csize, MPI_AINT, comm);
-  schedule->flags_length = 2*csize*sizeof(FLAG_t);
+  schedule->flags_length = 2*csize*sizeof(FLAG_t); // size of memory to expose to other ranks via window
 
   schedule->requests = malloc(3 * csize * sizeof(MPI_Request*));
   MPI_Request **requests_rputFLAG = &(schedule->requests[0 * csize * sizeof(MPI_Request*)]); // circumvent the request?
@@ -576,7 +505,7 @@ static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedul
 }
 
 static inline int a2av_sched_trigger_push(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                          void *flags, int *fsize, int *req_count,
+                                          MPI_Win win, MPI_Comm comm,
                                           const void *sendbuf, const int *sendcounts, const int *sdispls,
                                           MPI_Aint sendext, MPI_Datatype sendtype,
                                                 void *recvbuf, const int *recvcounts, const int *rdispls,
@@ -590,101 +519,5 @@ static inline int a2av_sched_trigger_push(int crank, int csize, PNBC_OSC_Schedul
   }
 
   return res;
-}
-
-static inline int a2av_sched_linear_rget(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                         void *flags, int *fsize, int *req_count,
-                                         const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                         MPI_Aint sendext, MPI_Datatype sendtype,
-                                               void *recvbuf, const int *recvcounts, const int *rdispls,
-                                         MPI_Aint recvext, MPI_Datatype recvtype,
-                                         MPI_Aint *abs_sdispls_other) {
-  int res;
-  char *rbuf, *sbuf;
-
-  // schedule a copy for the local MPI process, if needed
-  if (recvcounts[crank] != 0) {
-    sbuf = (char *) sendbuf + sdispls[crank] * sendext;
-    rbuf = (char *) recvbuf + rdispls[crank] * recvext;
-    res = PNBC_OSC_Sched_copy(sbuf, false, sendcounts[crank], sendtype,
-                              rbuf, false, recvcounts[crank], recvtype, schedule, false);
-    if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
-      OBJ_RELEASE(schedule);
-      return res;
-    }
-  }
-
-  *req_count = csize - 1;
-
-  // schedule a get for each remote target, if needed
-  for (int dist = 1 ; dist < csize ; ++dist) {
-    // start from dist==1 to exclude local rank, local is a copy not a get
-    int orank = (crank + dist) % csize;
-    if (recvcounts[orank] != 0) {
-      rbuf = (char *) recvbuf + rdispls[orank] * recvext;
-
-      res = PNBC_OSC_Sched_rget(rbuf, orank,
-                                sendcounts[orank], sendtype,
-                                recvcounts[orank], recvtype,
-                                abs_sdispls_other[orank],
-                                schedule, false);
-
-      if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
-        OBJ_RELEASE(schedule);
-        return res;
-      }
-
-    }
-  }
-
-  return OMPI_SUCCESS;
-}
-
-static inline int a2av_sched_linear_rput(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                         void *flags, int *fsize, int *req_count,
-                                         const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                         MPI_Aint sendext, MPI_Datatype sendtype,
-                                               void *recvbuf, const int *recvcounts, const int *rdispls,
-                                         MPI_Aint recvext, MPI_Datatype recvtype,
-                                         MPI_Aint *abs_rdispls_other) {
-  int res;
-  char *rbuf, *sbuf;
-
-  // schedule a copy for the local MPI process, if needed
-  if (sendcounts[crank] != 0) {
-    sbuf = (char *) sendbuf + sdispls[crank] * sendext;
-    rbuf = (char *) recvbuf + rdispls[crank] * recvext;
-    res = PNBC_OSC_Sched_copy(sbuf, false, sendcounts[crank], sendtype,
-                              rbuf, false, recvcounts[crank], recvtype, schedule, false);
-    if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
-      OBJ_RELEASE(schedule);
-      return res;
-    }
-  }
-
-  *req_count = csize - 1;
-
-  // schedule a put for each remote target, if needed
-  for (int dist = 1 ; dist < csize ; ++dist) {
-    // start from dist==1 to exclude local rank, local is a copy not a put
-    int orank = (crank + dist) % csize;
-    if (sendcounts[orank] != 0) {
-      sbuf = (char *) sendbuf + sdispls[orank] * sendext;
-
-      res = PNBC_OSC_Sched_rput(sbuf, orank,
-                                sendcounts[orank], sendtype,
-                                recvcounts[orank], recvtype,
-                                abs_rdispls_other[orank],
-                                schedule, false);
-
-      if (OPAL_UNLIKELY(OMPI_SUCCESS != res)) {
-        OBJ_RELEASE(schedule);
-        return res;
-      }
-
-    }
-  }
-
-  return OMPI_SUCCESS;
 }
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
@@ -56,7 +56,7 @@ typedef enum {
 static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedule *schedule,
                                           MPI_Win win, MPI_Comm comm,
 //                                          FLAG_t **flags,
-                                          int *fsize,
+                                          //int *fsize,
                                           const void *sendbuf, const int *sendcounts, const int *sdispls,
                                           MPI_Aint sendext, MPI_Datatype sendtype,
                                                 void *recvbuf, const int *recvcounts, const int *rdispls,
@@ -104,6 +104,7 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
   MPI_Aint *abs_rdispls_other, *abs_rdispls_local;
   MPI_Win win, winflag;
   void *flags = NULL;
+  schedule->flags_length=0;
   int fsize = 0;
   int req_count;
   ompi_coll_libpnbc_osc_module_t *libpnbc_osc_module = (ompi_coll_libpnbc_osc_module_t*) module;
@@ -332,7 +333,7 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
                                abs_rdispls_other);
                              //abs_sdispls_other);
     case algo_trigger_pull:
-  res = a2av_sched_trigger_pull(crank, csize, schedule, win, comm, &fsize, //flags, &fsize, &req_count,
+  res = a2av_sched_trigger_pull(crank, csize, schedule, win, comm, //&fsize, //flags, &fsize, &req_count,
                                sendbuf, sendcounts, sdispls, sendext, sendtype,
                                recvbuf, recvcounts, rdispls, recvext, recvtype,
                                abs_rdispls_other);
@@ -362,7 +363,7 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
     return res;
   }
 
-  if (0 == fsize) {
+  if (0 == schedule->flags_length) {
     winflag = MPI_WIN_NULL;
   } else {
     // create a dynamic window - flags will be signalled here
@@ -377,7 +378,7 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
     }
 
     // attach the flags memory to the winflag window (fsize provided by the schedule)
-    res = win->w_osc_module->osc_win_attach(winflag, schedule->flags, fsize);
+    res = win->w_osc_module->osc_win_attach(winflag, schedule->flags, schedule->flags_length);
     if (OMPI_SUCCESS != res) {
       PNBC_OSC_Error ("MPI Error in win_create_dynamic (%i)", res);
       free(abs_rdispls_other);
@@ -417,7 +418,7 @@ static int pnbc_osc_alltoallv_init(const void* sendbuf, const int *sendcounts, c
 static const int FLAG_TRUE = !0;
 
 static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedule *schedule,
-                                          MPI_Win win, MPI_Comm comm, int *fsize,
+                                          MPI_Win win, MPI_Comm comm, //int *fsize,
                                           const void *sendbuf, const int *sendcounts, const int *sdispls,
                                           MPI_Aint sendext, MPI_Datatype sendtype,
                                                 void *recvbuf, const int *recvcounts, const int *rdispls,
@@ -456,7 +457,7 @@ static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedul
     MPI_Get_address(&flags_rma_put_DONE[i], &DONE_displs_local[i]);
   }
   MPI_Alltoall(flag_displs_local, 2*csize, MPI_AINT, flag_displs_other, 2*csize, MPI_AINT, comm);
-  *fsize = 2*csize*sizeof(FLAG_t);
+  schedule->flags_length = 2*csize*sizeof(FLAG_t);
 
   schedule->requests = malloc(3 * csize * sizeof(MPI_Request*));
   MPI_Request **requests_rputFLAG = &(schedule->requests[0 * csize * sizeof(MPI_Request*)]); // circumvent the request?

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_alltoallv_init.c
@@ -446,7 +446,7 @@ static inline int a2av_sched_trigger_pull(int crank, int csize, PNBC_OSC_Schedul
   triggerable_t *triggers_phase4 = &(schedule->triggers[4 * csize * sizeof(triggerable_t)]);
   triggerable_t *triggers_phase5 = &(schedule->triggers[5 * csize * sizeof(triggerable_t)]);
 
-  schedule->flags = malloc(5 * csize * sizeof(FLAG_t));
+  schedule->flags = (FLAG_t*) malloc(5 * csize * sizeof(FLAG_t));
   FLAG_t *flags_rma_put_FLAG = &(schedule->flags[0 * csize * sizeof(FLAG_t)]); // needs exposure via MPI window
   FLAG_t *flags_rma_put_DONE = &(schedule->flags[1 * csize * sizeof(FLAG_t)]); // needs exposure via MPI window
   FLAG_t *flags_request_FLAG = &(schedule->flags[2 * csize * sizeof(FLAG_t)]); // local usage only

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_internal.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_internal.h
@@ -205,9 +205,9 @@ int PNBC_OSC_Schedule_request(PNBC_OSC_Schedule *schedule, ompi_communicator_t *
                               ompi_coll_libpnbc_osc_module_t *module, bool persistent,
                               ompi_request_t **request, void *tmpbuf);
 int PNBC_OSC_Schedule_request_win(PNBC_OSC_Schedule *schedule, ompi_communicator_t *comm,
-                                  ompi_win_t *win,ompi_win_t *winflag, int req_count,
+                                  ompi_win_t *win,
                                   ompi_coll_libpnbc_osc_module_t *module,
-                                  bool persistent, ompi_request_t **request, void *tmpbuf);
+                                  bool persistent, ompi_request_t **request);
   
 int PNBC_OSC_Start(PNBC_OSC_Handle *handle);
 int PNBC_OSC_Progress(PNBC_OSC_Handle *handle);

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_schedule.c
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_schedule.c
@@ -351,42 +351,20 @@ int PNBC_OSC_Schedule_request(PNBC_OSC_Schedule *schedule, ompi_communicator_t *
 }
 
 int PNBC_OSC_Schedule_request_win(PNBC_OSC_Schedule *schedule, ompi_communicator_t *comm,
-                                  ompi_win_t *win, ompi_win_t *winflag, int req_count,
+                                  ompi_win_t *win,
                                   ompi_coll_libpnbc_osc_module_t *module,
-                                  bool persistent, ompi_request_t **request, void *tmpbuf) {
-  int ret;
+                                  bool persistent, ompi_request_t **request) {
   bool need_register = false;
   ompi_coll_libpnbc_osc_request_t *handle;
-
-  /* no operation (e.g. one process barrier)? */
-  if (((int *)schedule->data)[0] == 0 && schedule->data[sizeof(int)] == 0) {
-    ret = nbc_get_noop_request(persistent, request);
-    if (OMPI_SUCCESS != ret) {
-      return OMPI_ERR_OUT_OF_RESOURCE;
-    }
-
-    OBJ_RELEASE(schedule);
-    free(tmpbuf);
-
-    return OMPI_SUCCESS;
-  }
 
   OMPI_COLL_LIBPNBC_OSC_REQUEST_ALLOC(comm, persistent, handle);
   if (NULL == handle) return OMPI_ERR_OUT_OF_RESOURCE;
 
-  handle->req_count = 0;
   handle->nbc_complete = persistent ? true : false;
   handle->schedule = schedule;
-  handle->schedule->row_offset = 0;
   handle->comm = comm;
   handle->win = win;
-  handle->winflag = winflag;
   handle->comminfo = module;
-  handle->tmpbuf = tmpbuf;
-  if (req_count > 0)
-    handle->req_array = malloc(req_count*sizeof(MPI_Request));
-  else
-    handle->req_array = NULL;
 
   /******************** Do the shadow comm administration ...  ***************/
 

--- a/ompi/mca/coll/libpnbc_osc/pnbc_osc_schedule.h
+++ b/ompi/mca/coll/libpnbc_osc/pnbc_osc_schedule.h
@@ -147,6 +147,7 @@ struct PNBC_OSC_Schedule {
   int trigger_arrays_length;            // for trigger-based schedule
   triggerable_array *trigger_arrays;    // for trigger-based schedule
   FLAG_t *flags;                        // for trigger-based schedule
+  int flags_length;                     // for tracking size of flags array
   MPI_Request **requests;               // for trigger-based schedule
   any_args_t *action_args_list;         // for trigger-based schedule
   int number_of_rounds;                 // length of array: rounds


### PR DESCRIPTION
Window now has user data buffer attached and internally allocated flag memory attached.

Removed dead code for 2 algorithms that will not be implemented (rget and rput).

Adjusted creation of top-level request from schedule to remove usages of old NBC fields.